### PR TITLE
Fix namespace issues and compilation on modern environment

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -2245,8 +2245,8 @@ extern CBlockTreeDB *pblocktree;
 struct CBlockTemplate
 {
     CBlock block;
-    std::vector<int64_t> vTxFees;
-    std::vector<int64_t> vTxSigOps;
+    std::vector<boost::int64_t> vTxFees;
+    std::vector<boost::int64_t> vTxSigOps;
 };
 
 #if defined(_M_IX86) || defined(__i386__) || defined(__i386) || defined(_M_X64) || defined(__x86_64__) || defined(_M_AMD64)

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -103,7 +103,7 @@ DEBUGFLAGS=-g
 
 # CXXFLAGS can be specified on the make command line, so we use xCXXFLAGS that only
 # adds some defaults in front. Unfortunately, CXXFLAGS=... $(CXXFLAGS) does not work.
-xCXXFLAGS=-O2 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter \
+xCXXFLAGS=-O2 -pthread -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -std=c++11 \
     $(DEBUGFLAGS) $(DEFS) $(HARDENING) $(CXXFLAGS)
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include "rpcconsole.h"
 #include "ui_rpcconsole.h"
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -148,15 +148,15 @@ Value getmininginfo(const Array& params, bool fHelp)
 
     Object obj;
     obj.push_back(Pair("blocks",        (int)nBestHeight));
-    obj.push_back(Pair("currentblocksize",(uint64_t)nLastBlockSize));
-    obj.push_back(Pair("currentblocktx",(uint64_t)nLastBlockTx));
+    obj.push_back(Pair("currentblocksize",(boost::uint64_t)nLastBlockSize));
+    obj.push_back(Pair("currentblocktx",(boost::uint64_t)nLastBlockTx));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     obj.push_back(Pair("generate",      GetBoolArg("-gen")));
     obj.push_back(Pair("genproclimit",  (int)GetArg("-genproclimit", -1)));
     obj.push_back(Pair("hashespersec",  gethashespersec(params, false)));
     obj.push_back(Pair("networkhashps", getnetworkhashps(params, false)));
-    obj.push_back(Pair("pooledtx",      (uint64_t)mempool.size()));
+    obj.push_back(Pair("pooledtx",      (boost::uint64_t)mempool.size()));
     obj.push_back(Pair("testnet",       fTestNet));
     return obj;
 }
@@ -495,7 +495,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
     pblock->nNonce = 0;
 
     Array transactions;
-    map<uint256, int64_t> setTxIndex;
+    map<uint256, boost::int64_t> setTxIndex;
     int i = 0;
     BOOST_FOREACH (CTransaction& tx, pblock->vtx)
     {
@@ -546,16 +546,16 @@ Value getblocktemplate(const Array& params, bool fHelp)
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
     result.push_back(Pair("coinbaseaux", aux));
-    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].vout[0].nValue));
+    result.push_back(Pair("coinbasevalue", (boost::int64_t)pblock->vtx[0].vout[0].nValue));
     result.push_back(Pair("target", hashTarget.GetHex()));
-    result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
+    result.push_back(Pair("mintime", (boost::int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
-    result.push_back(Pair("sigoplimit", (int64_t)MAX_BLOCK_SIGOPS));
-    result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SIZE));
-    result.push_back(Pair("curtime", (int64_t)pblock->nTime));
+    result.push_back(Pair("sigoplimit", (boost::int64_t)MAX_BLOCK_SIGOPS));
+    result.push_back(Pair("sizelimit", (boost::int64_t)MAX_BLOCK_SIZE));
+    result.push_back(Pair("curtime", (boost::int64_t)pblock->nTime));
     result.push_back(Pair("bits", HexBits(pblock->nBits)));
-    result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
+    result.push_back(Pair("height", (boost::int64_t)(pindexPrev->nHeight+1)));
 
     return result;
 }

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -6,7 +6,6 @@
 #include <boost/tuple/tuple.hpp>
 
 using namespace std;
-using namespace boost;
 
 #include "script.h"
 #include "keystore.h"
@@ -15,6 +14,8 @@ using namespace boost;
 #include "main.h"
 #include "sync.h"
 #include "util.h"
+
+using namespace boost;
 
 bool CheckSig(vector<unsigned char> vchSig, const vector<unsigned char> &vchPubKey, const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, int flags);
 


### PR DESCRIPTION
The codebase being pretty outdated, I had issues with compiling in on a modern Bookworm 12.5 Debian system.

These are fixes basically forcing c++11 standard in GCC and fixing namespace issues (see [this PR](https://github.com/dogecoin/dogecoin/pull/283) )

I manually compiled boost 1.50 (with options --with-system --with-filesystem --with-program_options --with-thread) and openssl 1.0.1t and overrided the search path:

```export BOOST_INCLUDE_PATH="/path/to/boost_1_50_0"
export BOOST_LIB_PATH="/path/to/boost_1_50_0/stage/lib"
export OPENSSL_INCLUDE_PATH="/path/to/openssl-1.0.1t/include"
export OPENSSL_LIB_PATH="/path/to/openssl-1.0.1t"

make -f makefile.unix  USE_UPNP=-```